### PR TITLE
don't require DEV env var for cors

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ directory with a `.unison` folder.
 
 For a slightly optimized workflow, you can have live reloading with [elm-live](https://github.com/wking-io/elm-live)
 
-- Start the haskell server in dev mode
+- Start the haskell server
 
       // One or the other
-      DEV=true cabal v2-run
-      DEV=true stack run
+      cabal v2-run
+      stack run
 
 - Use elm-live
 

--- a/server-src/Main.hs
+++ b/server-src/Main.hs
@@ -15,7 +15,7 @@ import Data.Text (Text)
 import Network.HTTP.Types hiding (StdMethod(..))
 import Network.Wai
 import Network.Wai.Handler.Warp
-import Network.Wai.Middleware.Cors
+import Network.Wai.Middleware.Cors (cors, simpleCorsResourcePolicy)
 import Paths_unison_browser (getDataFileName)
 import Prelude hiding (head)
 import System.Directory
@@ -58,24 +58,19 @@ main =
             _ ->
               throwIO err
 
-      isDev :: Bool <-
-        isJust <$> lookupEnv "DEV"
-
       runSettings
         (defaultSettings
-          & setBeforeMainLoop (do
-              putStrLn ("Running on 127.0.0.1:" ++ show port)
-              when isDev do
-                putStrLn "Developer mode: allowing cross-origin requests")
+          & setBeforeMainLoop
+              (putStrLn
+                (concat
+                  [ "Running on 127.0.0.1:"
+                  , show port
+                  , ", allowing cross-origin requests"
+                  ]))
           & setHost "127.0.0.1"
           & setPort port)
-        ((if isDev then simpleCorsWithContentType else id) app)
+        (cors (\_ -> Just simpleCorsResourcePolicy) app)
         `catchIOError` handler
-
-  where
-    simpleCorsWithContentType :: Middleware
-    simpleCorsWithContentType =
-      cors (\_ -> Just simpleCorsResourcePolicy)
 
 
 printUsage :: IO ()


### PR DESCRIPTION
Since this server is really only usable on localhost for browsing a local `.unison` folder, it seems simpler to just always allow cross-origin requests for now.