### PR TITLE
better naming: getType -> getTypeDecl

### DIFF
--- a/client-src/Main.elm
+++ b/client-src/Main.elm
@@ -70,7 +70,7 @@ init _ url key =
                 , branches = BranchDict.empty
                 , terms = HashDict.empty idEquality idHashing
                 , termTypes = HashDict.empty idEquality idHashing
-                , types = HashDict.empty idEquality idHashing
+                , typeDecls = HashDict.empty idEquality idHashing
                 , parents = BranchDict.empty
                 , successors = BranchDict.empty
                 }
@@ -107,8 +107,8 @@ update message model =
         Http_GetTerm result ->
             updateHttpGetTerm result model
 
-        Http_GetTermTypesAndTypes result ->
-            updateHttpGetTermTypesAndTypes result model
+        Http_GetTermTypesAndTypeDecls result ->
+            updateHttpGetTermTypesAndTypeDecls result model
 
         User_FocusBranch hash ->
             updateUserFocusBranch hash model
@@ -231,7 +231,7 @@ updateHttpGetBranch2 ( hash, { branches, parents, successors } ) model =
                     model.codebase.successors
             , terms = model.codebase.terms
             , termTypes = model.codebase.termTypes
-            , types = model.codebase.types
+            , typeDecls = model.codebase.typeDecls
             }
       }
     , case HashDict.get hash newBranches of
@@ -243,8 +243,8 @@ updateHttpGetBranch2 ( hash, { branches, parents, successors } ) model =
             Task.map2
                 Tuple.pair
                 (getMissingTermTypes model branch)
-                (getMissingTypes model branch)
-                |> Task.attempt Http_GetTermTypesAndTypes
+                (getMissingTypeDecls model branch)
+                |> Task.attempt Http_GetTermTypesAndTypeDecls
     )
 
 
@@ -276,7 +276,7 @@ updateHttpGetTerm2 ( id, response ) model =
             , head = model.codebase.head
             , branches = model.codebase.branches
             , termTypes = model.codebase.termTypes
-            , types = model.codebase.types
+            , typeDecls = model.codebase.typeDecls
             , parents = model.codebase.parents
             , successors = model.codebase.successors
             }
@@ -285,26 +285,26 @@ updateHttpGetTerm2 ( id, response ) model =
     )
 
 
-updateHttpGetTermTypesAndTypes :
+updateHttpGetTermTypesAndTypeDecls :
     Result (Http.Error Bytes) ( List ( Id, Type Symbol ), List ( Id, Declaration Symbol ) )
     -> Model
     -> ( Model, Cmd message )
-updateHttpGetTermTypesAndTypes result model =
+updateHttpGetTermTypesAndTypeDecls result model =
     case result of
         Err err ->
-            ( { model | errors = Err_GetTypes err :: model.errors }
+            ( { model | errors = Err_GetTypeDecls err :: model.errors }
             , Cmd.none
             )
 
         Ok response ->
-            updateHttpGetTermTypesAndTypes2 response model
+            updateHttpGetTermTypesAndTypeDecls2 response model
 
 
-updateHttpGetTermTypesAndTypes2 :
+updateHttpGetTermTypesAndTypeDecls2 :
     ( List ( Id, Type Symbol ), List ( Id, Declaration Symbol ) )
     -> Model
     -> ( Model, Cmd message )
-updateHttpGetTermTypesAndTypes2 ( termTypes, types ) model =
+updateHttpGetTermTypesAndTypeDecls2 ( termTypes, types ) model =
     ( { model
         | codebase =
             { termTypes =
@@ -312,10 +312,10 @@ updateHttpGetTermTypesAndTypes2 ( termTypes, types ) model =
                     (\( id, type_ ) -> HashDict.insert id type_)
                     model.codebase.termTypes
                     termTypes
-            , types =
+            , typeDecls =
                 List.foldl
                     (\( id, declaration ) -> HashDict.insert id declaration)
-                    model.codebase.types
+                    model.codebase.typeDecls
                     types
 
             -- unchanged
@@ -385,7 +385,7 @@ updateUserFocusBranch hash model =
                     , branches = model.codebase.branches
                     , terms = model.codebase.terms
                     , termTypes = model.codebase.termTypes
-                    , types = model.codebase.types
+                    , typeDecls = model.codebase.typeDecls
                     , parents = model.codebase.parents
                     , successors = model.codebase.successors
                     }
@@ -393,8 +393,8 @@ updateUserFocusBranch hash model =
             , Task.map2
                 Tuple.pair
                 (getMissingTermTypes model branch)
-                (getMissingTypes model branch)
-                |> Task.attempt Http_GetTermTypesAndTypes
+                (getMissingTypeDecls model branch)
+                |> Task.attempt Http_GetTermTypesAndTypeDecls
             )
 
 
@@ -426,8 +426,8 @@ updateUserToggleBranch hash model =
             Task.map2
                 Tuple.pair
                 (getMissingTermTypes model branch)
-                (getMissingTypes model branch)
-                |> Task.attempt Http_GetTermTypesAndTypes
+                (getMissingTypeDecls model branch)
+                |> Task.attempt Http_GetTermTypesAndTypeDecls
     )
 
 

--- a/client-src/Ucb/Main/Message.elm
+++ b/client-src/Ucb/Main/Message.elm
@@ -35,6 +35,6 @@ type Message
         )
     | Http_GetHeadHash (Result (Http.Error String) (Http.Response BranchHash))
     | Http_GetTerm (Result (Http.Error Bytes) ( Id, Http.Response (Term Symbol) ))
-    | Http_GetTermTypesAndTypes (Result (Http.Error Bytes) ( List ( Id, Type Symbol ), List ( Id, Declaration Symbol ) ))
+    | Http_GetTermTypesAndTypeDecls (Result (Http.Error Bytes) ( List ( Id, Type Symbol ), List ( Id, Declaration Symbol ) ))
     | UrlChanged Url.Url
     | LinkClicked Browser.UrlRequest

--- a/client-src/Ucb/Main/Model.elm
+++ b/client-src/Ucb/Main/Model.elm
@@ -26,8 +26,8 @@ type Error
     | Err_GetRawCausal (Http.Error Bytes)
     | Err_GetTerm (Http.Error Bytes)
     | Err_GetTermTypes (Http.Error Bytes)
-    | Err_GetType (Http.Error Bytes)
-    | Err_GetTypes (Http.Error Bytes)
+    | Err_GetTypeDecl (Http.Error Bytes)
+    | Err_GetTypeDecls (Http.Error Bytes)
 
 
 type alias Model =
@@ -43,7 +43,7 @@ type alias Model =
         , branches : BranchDict Branch
         , terms : HashDict Id (Term Symbol)
         , termTypes : HashDict Id (Type Symbol)
-        , types : HashDict Id (Declaration Symbol)
+        , typeDecls : HashDict Id (Declaration Symbol)
 
         -- Mapping from branch to its parent(s). The codebase doesn't provide
         -- this, we just discover and cache it lazily as you move down into
@@ -112,12 +112,12 @@ getMissingTermTypes model (Branch causal) =
 {-| Given a branch we just switched to, fetch all of the (shallow) type
 declarations that we haven't already.
 -}
-getMissingTypes :
+getMissingTypeDecls :
     Model
     -> Branch
     -> Task (Http.Error Bytes) (List ( Id, Declaration Symbol ))
-getMissingTypes model (Branch causal) =
-    getTypes
+getMissingTypeDecls model (Branch causal) =
+    getTypeDecls
         model.api.unison
         (List.filterMap
             (\reference ->
@@ -126,7 +126,7 @@ getMissingTypes model (Branch causal) =
                         Nothing
 
                     Derived id ->
-                        case HashDict.get id model.codebase.types of
+                        case HashDict.get id model.codebase.typeDecls of
                             Nothing ->
                                 Just id
 

--- a/client-src/Ucb/Main/View/Branch.elm
+++ b/client-src/Ucb/Main/View/Branch.elm
@@ -234,7 +234,7 @@ viewBranchType model reference name links =
                 ]
 
         Derived id ->
-            case HashDict.get id model.codebase.types of
+            case HashDict.get id model.codebase.typeDecls of
                 Nothing ->
                     none
 

--- a/client-src/Ucb/Unison/Codebase/API.elm
+++ b/client-src/Ucb/Unison/Codebase/API.elm
@@ -2,7 +2,7 @@ module Ucb.Unison.Codebase.API exposing
     ( UnisonCodebaseAPI
     , getBranch
     , getTermTypes
-    , getTypes
+    , getTypeDecls
     )
 
 import Bytes exposing (Bytes)
@@ -32,7 +32,7 @@ type alias UnisonCodebaseAPI =
     , getRawCausal : BranchHash -> Task (Http.Error Bytes) ( BranchHash, Http.Response (RawCausal RawBranch) )
     , getTerm : Id -> Task (Http.Error Bytes) ( Id, Http.Response (Term Symbol) )
     , getTermType : Id -> Task (Http.Error Bytes) ( Id, Http.Response (Type Symbol) )
-    , getType : Id -> Task (Http.Error Bytes) ( Id, Http.Response (Declaration Symbol) )
+    , getTypeDecl : Id -> Task (Http.Error Bytes) ( Id, Http.Response (Declaration Symbol) )
     }
 
 
@@ -300,13 +300,13 @@ getTermTypes api ids =
                 (getTermTypes api ids_)
 
 
-{-| Batch getType
+{-| Batch getTypeDecl
 -}
-getTypes :
+getTypeDecls :
     UnisonCodebaseAPI
     -> List Id
     -> Task (Http.Error Bytes) (List ( Id, Declaration Symbol ))
-getTypes api ids =
+getTypeDecls api ids =
     case ids of
         [] ->
             Task.succeed []
@@ -314,5 +314,5 @@ getTypes api ids =
         id :: ids_ ->
             Task.map2
                 (\( r, s ) rs -> ( r, s.body ) :: rs)
-                (api.getType id)
-                (getTypes api ids_)
+                (api.getTypeDecl id)
+                (getTypeDecls api ids_)

--- a/client-src/Ucb/Unison/Codebase/API/GitHub.elm
+++ b/client-src/Ucb/Unison/Codebase/API/GitHub.elm
@@ -25,7 +25,7 @@ makeGitHubUnisonCodebaseAPI owner repo =
     , getRawCausal = getRawCausal owner repo
     , getTerm = Debug.todo "GitHub getTerm"
     , getTermType = Debug.todo "GitHub getTermType"
-    , getType = getType owner repo
+    , getTypeDecl = getTypeDecl owner repo
     }
 
 
@@ -86,12 +86,12 @@ getRawCausal owner repo hash =
         |> Task.map (\response -> ( hash, response ))
 
 
-getType :
+getTypeDecl :
     String
     -> String
     -> Id
     -> Task (Http.Error Bytes) ( Id, Http.Response (Declaration Symbol) )
-getType owner repo id =
+getTypeDecl owner repo id =
     GitHub.getFile
         { owner = owner
         , repo = repo

--- a/client-src/Ucb/Unison/Codebase/API/LocalServer.elm
+++ b/client-src/Ucb/Unison/Codebase/API/LocalServer.elm
@@ -39,7 +39,7 @@ makeLocalServerUnisonCodebaseAPI isDev =
     , getRawCausal = getRawCausal isDev
     , getTerm = getTerm isDev
     , getTermType = getTermType isDev
-    , getType = getType isDev
+    , getTypeDecl = getTypeDecl isDev
     }
 
 
@@ -95,11 +95,11 @@ getTermType isDev id =
         |> Task.map (\response -> ( id, response ))
 
 
-getType :
+getTypeDecl :
     Bool
     -> Id
     -> Task (Http.Error Bytes) ( Id, Http.Response (Declaration Symbol) )
-getType isDev id =
+getTypeDecl isDev id =
     Http.getBytes
         { decoder = V1.declarationDecoder
         , headers = []


### PR DESCRIPTION
The folder in the database is called `/types/` (hence the original naming), but it actually contains type declarations.