### PR TITLE
LRU cache in local server

### DIFF
--- a/server-src/Cache.hs
+++ b/server-src/Cache.hs
@@ -1,0 +1,105 @@
+module Cache
+  ( Cache
+  , Key(..)
+  , newCache
+  , readCache
+  , writeCache
+  ) where
+
+import Data.ByteString (ByteString)
+import Data.Hashable (Hashable)
+import Data.IORef
+import Data.Text (Text)
+import Numeric.Natural (Natural)
+import GHC.Generics (Generic)
+
+import qualified Data.HashPSQ as PSQ
+
+
+type PSQ
+  = PSQ.HashPSQ
+
+data Key
+  = KeyBranch Text
+  | KeyDeclaration Text
+  | KeyTerm Text
+  | KeyTermType Text
+  deriving stock (Eq, Generic, Ord)
+  deriving anyclass (Hashable)
+
+type Cache
+  = IORef (Natural, Natural, PSQ Key Natural ByteString)
+
+-- | Hard-coded cache capacity. Oldest entries are evicted.
+capacity :: Natural
+capacity =
+  4096
+
+newCache :: IO Cache
+newCache =
+  newIORef (0, 0, PSQ.empty)
+
+readCache :: Cache -> Key -> IO (Maybe ByteString)
+readCache ref key =
+  atomicModifyIORef' ref (readCache_ key)
+
+readCache_
+  :: Key
+  -> (Natural, Natural, PSQ Key Natural ByteString)
+  -> ((Natural, Natural, PSQ Key Natural ByteString), Maybe ByteString)
+readCache_ key (now, size, cache) =
+  let
+    result :: Maybe ByteString
+    cache2 :: PSQ Key Natural ByteString
+    (result, cache2) =
+      PSQ.alter
+        (\case
+          Nothing -> (Nothing, Nothing)
+          Just (_, value) -> (Just value, Just (now, value)))
+        key
+        cache
+
+    now2 :: Natural
+    now2 =
+      now + 1
+  in
+    now2 `seq` ((now2, size, cache2), result)
+
+
+writeCache :: Cache -> Key -> ByteString -> IO ()
+writeCache ref key value =
+  atomicModifyIORef' ref (\x -> (writeCache_ key value x, ()))
+
+writeCache_
+  :: Key
+  -> ByteString
+  -> (Natural, Natural, PSQ Key Natural ByteString)
+  -> (Natural, Natural, PSQ Key Natural ByteString)
+writeCache_ key value (now, size, cache) =
+  let
+    -- First, optimistically insert, even if we are at capacity (because we
+    -- might just replace an existing entry, which is ok).
+    size2 :: Natural
+    cache2 :: PSQ Key Natural ByteString
+    (size2, cache2) =
+      PSQ.alter
+        (\case
+          Nothing -> (size+1, Just (now, value))
+          Just _  -> (size,   Just (now, value)))
+        key
+        cache
+
+    -- Then, if we went past capacity, delete the minimum.
+    size3 :: Natural
+    cache3 :: PSQ Key Natural ByteString
+    (size3, cache3) =
+      if size2 > capacity then -- if >, should always be == capacity+1
+        (size, PSQ.deleteMin cache2)
+      else
+        (size2, cache2)
+
+    now2 :: Natural
+    now2 =
+      now + 1
+  in
+    now2 `seq` size3 `seq` (now2, size3, cache3)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,5 @@
 resolver: lts-14.2
 extra-deps:
+  - hashable-1.3.0.0
   - http2-2.0.3
   - warp-3.3.0

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,6 +5,13 @@
 
 packages:
 - completed:
+    hackage: hashable-1.3.0.0@sha256:7ad8edaa681e81162ddddb4d703a9cffe6a0c9ddcfede31cf6569507ed3f1ddb,5179
+    pantry-tree:
+      size: 1521
+      sha256: b80a3632cc3782099576348981f21ead5ba759e83fa610e02feb33901fdac38c
+  original:
+    hackage: hashable-1.3.0.0
+- completed:
     hackage: http2-2.0.3@sha256:c08885f0fd26ae035b169029b782cc693cc30e4d7a3b6f21a61de31085e8cfae,17644
     pantry-tree:
       size: 44789

--- a/unison-browser.cabal
+++ b/unison-browser.cabal
@@ -9,12 +9,25 @@ executable unison-browser
     base ^>= 4.12.0,
     bytestring ^>= 0.10.8,
     directory ^>= 1.3.3,
+    hashable ^>= 1.3.0,
     http-types ^>= 0.12.3,
+    psqueues ^>= 0.2.7,
     text ^>= 1.2.3,
     wai ^>= 3.2.2,
     wai-cors ^>= 0.2.7,
     warp ^>= 3.3.0,
+  default-extensions:
+    BlockArguments
+    DeriveAnyClass
+    DeriveGeneric
+    DerivingStrategies
+    LambdaCase
+    OverloadedStrings
+    PatternSynonyms
+    ScopedTypeVariables
+    ViewPatterns
   default-language: Haskell2010
   ghc-options: -Wall -threaded
-  main-is: server-src/Main.hs
-  other-modules: Paths_unison_browser
+  hs-source-dirs: server-src
+  main-is: Main.hs
+  other-modules: Cache, Paths_unison_browser


### PR DESCRIPTION
This patch caches branches, types, etc. in memory in the haskell server, so it hits the filesystem much less often.