### PR TITLE
Track which term the user is hovering over

### DIFF
--- a/client-src/Ucb/Main/Message.elm
+++ b/client-src/Ucb/Main/Message.elm
@@ -24,6 +24,8 @@ type Message
     | User_ToggleBranch BranchHash
     | User_ToggleTerm Id
     | User_Search String
+    | User_HoverTerm Id
+    | User_LeaveTerm
     | Http_GetBranch
         (Result (Http.Error Bytes)
             ( BranchHash

--- a/client-src/Ucb/Main/Model.elm
+++ b/client-src/Ucb/Main/Model.elm
@@ -69,6 +69,9 @@ type alias Model =
 
         -- Search box
         , search : String
+
+        -- hover tracking
+        , hoveredTerm : Maybe Id
         , key : Nav.Key
         }
 

--- a/client-src/Ucb/Main/View/Branch.elm
+++ b/client-src/Ucb/Main/View/Branch.elm
@@ -182,6 +182,15 @@ viewBranchTerm2 model reference name _ =
                     [ codeFont
                     , onClick (User_ToggleTerm id)
                     , pointer
+                    , onMouseEnter (User_HoverTerm id)
+                    , onMouseLeave User_LeaveTerm
+                    , below <|
+                        if Just id == model.ui.hoveredTerm then
+                            -- TODO find the full name and print it
+                            el [] none
+
+                        else
+                            none
                     ]
                     [ text name2
                     , maybe


### PR DESCRIPTION
This just adds the necessary UI state and messages to update it, and leaves a stub in the view where you'll dig through the codebase to get the actual names.
That last step seemed rather involved, I figured one of you could do it way faster than I could.