### PR TITLE
Track which term the user is hovering over

### DIFF
--- a/client-src/Main.elm
+++ b/client-src/Main.elm
@@ -79,6 +79,7 @@ init _ url key =
                 { branches = BranchDict.empty
                 , terms = HashDict.empty idEquality idHashing
                 , search = ""
+                , hoveredTerm = Nothing
                 , key = key
                 }
             , errors = []
@@ -126,6 +127,12 @@ update message model =
 
         User_ToggleTerm id ->
             update_User_ToggleTerm id model
+
+        User_HoverTerm id ->
+            updateUserHoverTerm id model
+
+        User_LeaveTerm ->
+            updateUserLeaveTerm model
 
         UrlChanged _ ->
             ( model, Cmd.none )
@@ -545,6 +552,20 @@ update_User_ToggleTerm id model =
       }
     , command
     )
+
+
+updateUserHoverTerm : Id -> Model -> ( Model, Cmd Message )
+updateUserHoverTerm id model =
+    model.ui
+        |> (\oldUi -> { oldUi | hoveredTerm = Just id })
+        |> (\newUi -> ( { model | ui = newUi }, Cmd.none ))
+
+
+updateUserLeaveTerm : Model -> ( Model, Cmd Message )
+updateUserLeaveTerm model =
+    model.ui
+        |> (\oldUi -> { oldUi | hoveredTerm = Nothing })
+        |> (\newUi -> ( { model | ui = newUi }, Cmd.none ))
 
 
 subscriptions :

--- a/client-src/Main.elm
+++ b/client-src/Main.elm
@@ -402,15 +402,12 @@ update_User_Search :
     -> Model
     -> ( Model, Cmd msg )
 update_User_Search search model =
+    let
+        updateSearch oldUi =
+            { oldUi | search = String.toLower search }
+    in
     ( { model
-        | ui =
-            { search = String.toLower search
-
-            -- unchanged
-            , branches = model.ui.branches
-            , terms = model.ui.terms
-            , key = model.ui.key
-            }
+        | ui = updateSearch model.ui
       }
     , Cmd.none
     )
@@ -488,19 +485,19 @@ update_User_ToggleBranch :
     -> Model
     -> ( Model, Cmd Message )
 update_User_ToggleBranch hash model =
+    let
+        updateBranches oldUi =
+            { oldUi
+                | branches =
+                    HashDict.update
+                        hash
+                        (maybe True not >> Just)
+                        model.ui.branches
+            }
+    in
     ( { model
         | ui =
-            { branches =
-                HashDict.update
-                    hash
-                    (maybe True not >> Just)
-                    model.ui.branches
-
-            -- unchanged
-            , search = model.ui.search
-            , terms = model.ui.terms
-            , key = model.ui.key
-            }
+            updateBranches model.ui
       }
     , case HashDict.get hash model.codebase.branches of
         -- Should never be the case
@@ -538,16 +535,13 @@ update_User_ToggleTerm id model =
                 id
                 (maybe True not >> Just)
                 model.ui.terms
+
+        updateTerms oldUi =
+            { oldUi | terms = newTerms }
     in
     ( { model
         | ui =
-            { terms = newTerms
-
-            -- unchanged
-            , branches = model.ui.branches
-            , search = model.ui.search
-            , key = model.ui.key
-            }
+            updateTerms model.ui
       }
     , command
     )

--- a/client-src/Ucb/Main/Message.elm
+++ b/client-src/Ucb/Main/Message.elm
@@ -24,6 +24,8 @@ type Message
     | User_ToggleBranch BranchHash
     | User_ToggleTerm Id
     | User_Search String
+    | User_HoverTerm Id
+    | User_LeaveTerm
     | Http_GetBranch
         (Result (Http.Error Bytes)
             ( BranchHash

--- a/client-src/Ucb/Main/Model.elm
+++ b/client-src/Ucb/Main/Model.elm
@@ -69,6 +69,9 @@ type alias Model =
 
         -- Search box
         , search : String
+
+        -- hover tracking
+        , hoveredTerm : Maybe Id
         , key : Nav.Key
         }
 

--- a/client-src/Ucb/Main/View/Branch.elm
+++ b/client-src/Ucb/Main/View/Branch.elm
@@ -182,6 +182,15 @@ viewBranchTerm2 model reference name _ =
                     [ codeFont
                     , onClick (User_ToggleTerm id)
                     , pointer
+                    , onMouseEnter (User_HoverTerm id)
+                    , onMouseLeave User_LeaveTerm
+                    , below <|
+                        if Just id == model.ui.hoveredTerm then
+                            -- TODO find the full name and print it
+                            el [] none
+
+                        else
+                            none
                     ]
                     [ text name2
                     , maybe


### PR DESCRIPTION
This just adds the necessary UI state and messages to update it, and leaves a stub in the view where you'll dig through the codebase to get the actual names.
That last step seemed rather involved, I figured one of you could do it way faster than I could.


currently depends on https://github.com/unisonweb/elm-browser/pull/24