### PR TITLE
whittle Model down to View for view code

### DIFF
--- a/client-src/Main.elm
+++ b/client-src/Main.elm
@@ -9,7 +9,7 @@ import Misc exposing (..)
 import Task
 import Ucb.Main.Message exposing (Message(..))
 import Ucb.Main.Model exposing (..)
-import Ucb.Main.View exposing (view)
+import Ucb.Main.View exposing (viewModel)
 import Ucb.Unison.BranchDict as BranchDict exposing (BranchDict)
 import Ucb.Unison.Codebase.API exposing (..)
 import Ucb.Unison.Codebase.API.GitHub exposing (..)
@@ -35,7 +35,7 @@ main =
         { init = init
         , subscriptions = subscriptions
         , update = update
-        , view = view
+        , view = viewModel
         , onUrlRequest = LinkClicked
         , onUrlChange = UrlChanged
         }


### PR DESCRIPTION
This patch adds a `View` record that is meant to contain the bits of the model that the view code cares about. No functional changes, just a refactoring, will cause merge conflicts for #25 so I'll wait until that's merged @xilnocas 