### PR TITLE
Add some useful things to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 dist-newstyle/
 elm-stuff/
 index.html
+
+# Useful for playing around with unison codebases during development:
+.unison
+.unisonHistory
+scratch.u


### PR DESCRIPTION
Given that we always look for the unison codebase in $PWD, having it
(and related files) in .gitignore makes sense for development.