### PR TITLE
allow hovering over a type (kinda)

### DIFF
--- a/client-src/Main.elm
+++ b/client-src/Main.elm
@@ -80,7 +80,7 @@ init _ url key =
                 { branch = []
                 , terms = HashDict.empty idEquality idHashing
                 , search = ""
-                , hoveredTerm = Nothing
+                , hovered = Nothing
                 , key = key
                 }
             , errors = []
@@ -123,11 +123,11 @@ update message model =
         User_GetPatches hash ->
             update_User_GetPatches hash model
 
-        User_HoverTerm id ->
-            update_User_HoverTerm id model
+        User_Hover hover ->
+            update_User_HoverTerm hover model
 
-        User_LeaveTerm ->
-            update_User_LeaveTerm model
+        User_Unhover ->
+            update_User_Unhover model
 
         User_Search search ->
             update_User_Search search model
@@ -573,15 +573,18 @@ update_User_GetPatches hash model =
     )
 
 
-update_User_HoverTerm : Reference -> Model -> ( Model, Cmd message )
-update_User_HoverTerm reference model =
+update_User_HoverTerm :
+    Hover
+    -> Model
+    -> ( Model, Cmd message )
+update_User_HoverTerm hover model =
     let
         updateUI :
             ModelUI
             -> ModelUI
         updateUI ui =
             { ui
-                | hoveredTerm = Just reference
+                | hovered = Just hover
             }
 
         newModel : Model
@@ -595,15 +598,15 @@ update_User_HoverTerm reference model =
     )
 
 
-update_User_LeaveTerm : Model -> ( Model, Cmd message )
-update_User_LeaveTerm model =
+update_User_Unhover : Model -> ( Model, Cmd message )
+update_User_Unhover model =
     let
         updateUI :
             ModelUI
             -> ModelUI
         updateUI ui =
             { ui
-                | hoveredTerm = Nothing
+                | hovered = Nothing
             }
 
         newModel : Model

--- a/client-src/Ucb/Main/Message.elm
+++ b/client-src/Ucb/Main/Message.elm
@@ -1,8 +1,9 @@
-module Ucb.Main.Message exposing (..)
+module Ucb.Main.Message exposing (Message(..))
 
 import Browser
 import Bytes exposing (Bytes)
 import HashingContainers.HashSet exposing (HashSet)
+import Ucb.Main.Model exposing (Hover)
 import Ucb.Unison.BranchDict exposing (..)
 import Ucb.Util.Http as Http
 import Unison.Codebase.Branch exposing (..)
@@ -25,8 +26,8 @@ type Message
     | User_GetPatches BranchHash
     | User_ToggleTerm Id
     | User_Search String
-    | User_HoverTerm Reference
-    | User_LeaveTerm
+    | User_Hover Hover
+    | User_Unhover
     | Http_GetBranch
         (Result (Http.Error Bytes)
             ( BranchHash

--- a/client-src/Ucb/Main/Model.elm
+++ b/client-src/Ucb/Main/Model.elm
@@ -1,4 +1,13 @@
-module Ucb.Main.Model exposing (..)
+module Ucb.Main.Model exposing
+    ( Error(..)
+    , Hover(..)
+    , Model
+    , ModelCodebase
+    , ModelUI
+    , getMissingPatches
+    , getMissingTermTypes
+    , getMissingTypeDecls
+    )
 
 import Browser.Navigation as Nav
 import Bytes exposing (Bytes)
@@ -86,11 +95,22 @@ type alias ModelUI =
     , search : String
 
     -- Hover tracking
-    , hoveredTerm : Maybe Reference
+    , hovered : Maybe Hover
 
     -- mitchell: what's this thing?
     , key : Nav.Key
     }
+
+
+{-| Hovering over what?
+-}
+type Hover
+    = HoverTerm Reference
+    | HoverType
+        -- The term
+        Reference
+        -- The type
+        Reference
 
 
 {-| Given a branch, fetch all of its patches that we haven't already.

--- a/client-src/Ucb/Main/View.elm
+++ b/client-src/Ucb/Main/View.elm
@@ -40,13 +40,14 @@ type alias View =
     , getTypeDecl : Id -> Maybe (Declaration Symbol)
     , head : Branch
     , headHash : BranchHash
-    , hoveredTerm : Maybe Reference
+    , hovered : Maybe Hover
     , isTermVisible : Id -> Bool
     , parents : BranchHash -> List BranchHash
     , patches : List ( PatchHash, Patch )
     , search : String
     , successors : BranchHash -> List BranchHash
     , termNames : Referent -> List Name
+    , typeNames : Reference -> List Name
     }
 
 
@@ -101,7 +102,7 @@ makeViewFromModel2 model headHash head =
     , getTypeDecl = \id -> HashDict.get id model.codebase.typeDecls
     , head = head
     , headHash = headHash
-    , hoveredTerm = model.ui.hoveredTerm
+    , hovered = model.ui.hovered
     , isTermVisible =
         \id ->
             HashDict.get id model.ui.terms == Just True
@@ -125,6 +126,12 @@ makeViewFromModel2 model headHash head =
                 []
                 (HashSet.toList >> List.sortWith nameCompare)
                 (HashDict.get referent (branchHead head).cache.termToName)
+    , typeNames =
+        \reference ->
+            maybe
+                []
+                (HashSet.toList >> List.sortWith nameCompare)
+                (HashDict.get reference (branchHead head).cache.typeToName)
     }
 
 

--- a/client-src/Ucb/Main/View/Branch.elm
+++ b/client-src/Ucb/Main/View/Branch.elm
@@ -12,7 +12,7 @@ import Typeclasses.Classes.Equality as Equality
 import Typeclasses.Classes.Hashing as Hashing
 import Ucb.Main.Message exposing (..)
 import Ucb.Main.Model exposing (..)
-import Ucb.Main.View.Palette exposing (codeFont, hoverStyle)
+import Ucb.Main.View.Palette exposing (codeFont, hashColor, hoverStyle)
 import Ucb.Main.View.Term exposing (viewTerm)
 import Ucb.Main.View.Type exposing (viewType)
 import Unison.Codebase.Branch exposing (..)
@@ -202,7 +202,7 @@ viewBranchTerm2 view reference name _ =
                                     (column
                                         []
                                         (el
-                                            [ Font.color (rgb 0.5 0.5 0.5) ]
+                                            [ hashColor ]
                                             (text id.hash)
                                             :: List.map
                                                 (nameToString >> text)

--- a/client-src/Ucb/Main/View/Palette.elm
+++ b/client-src/Ucb/Main/View/Palette.elm
@@ -45,3 +45,8 @@ hoverStyle =
     , Border.solid
     , Border.width 1
     ]
+
+
+hashColor : Attribute message
+hashColor =
+    Font.color (rgb 0.5 0.5 0.5)

--- a/client-src/Ucb/Main/View/Palette.elm
+++ b/client-src/Ucb/Main/View/Palette.elm
@@ -1,6 +1,8 @@
 module Ucb.Main.View.Palette exposing (..)
 
-import Element exposing (Attribute)
+import Element exposing (Attribute, rgb)
+import Element.Background as Background
+import Element.Border as Border
 import Element.Font as Font
 
 
@@ -32,3 +34,14 @@ codeFont =
             }
         , Font.typeface "monospace"
         ]
+
+
+{-| Styling for hovered types/terms
+-}
+hoverStyle : List (Attribute message)
+hoverStyle =
+    [ Background.color (rgb 1 1 1)
+    , Border.color (rgb 0 0 0)
+    , Border.solid
+    , Border.width 1
+    ]


### PR DESCRIPTION
This patch partially fixes #43, I think I'll close that out and re-open a new ticket. Main problem: if you hover over e.g. `Foo` in the term

```
blah : Foo -> Bar -> Foo
```

then both `Foo`s will have their own tooltip T_T