### PR TITLE
basic branch-based SPA functionality

### DIFF
--- a/client-src/Ucb/Main/View/Branch.elm
+++ b/client-src/Ucb/Main/View/Branch.elm
@@ -367,11 +367,11 @@ viewCausal view hash causal =
         viewHash : BranchHash -> Element Message
         viewHash hash_ =
             el
-                [ onClick (User_FocusBranch hash_)
-                , pointer
+                [ pointer -- onClick (User_FocusBranch hash_)
+                -- , pointer
                 ]
                 -- TODO show full hash on hover
-                (text (String.left 7 hash_))
+                (link [] {url = "/branch/" ++ hash_, label = text (String.left 7 hash_)})
 
         viewParents : Element Message
         viewParents =

--- a/client-src/Ucb/Unison/Codebase/API/LocalServer.elm
+++ b/client-src/Ucb/Unison/Codebase/API/LocalServer.elm
@@ -3,6 +3,8 @@ module Ucb.Unison.Codebase.API.LocalServer exposing (makeLocalServerUnisonCodeba
 import Bytes exposing (Bytes)
 import Json.Decode
 import Task exposing (Task)
+import Url exposing (..)
+import Url.Builder as UrlBuilder exposing (..)
 import Ucb.Unison.Codebase.API exposing (..)
 import Ucb.Util.Http as Http
 import Ucb.Util.Task as Task
@@ -19,18 +21,26 @@ import Unison.Type exposing (..)
 
 {-| Haskell server localhost base url
 -}
-devBase : String
+devBase : Url
 devBase =
-    "http://localhost:8180/"
+  { protocol = Http
+  , host = "localhost"
+  , port_ = Just 8180
+  , path = ""
+  , query = Just ""
+  , fragment = Just "" 
+  }
+
+  --  "http://localhost:8180/"
 
 
 prefixIfDev : Bool -> String -> String
 prefixIfDev isDev path =
     if isDev then
-        devBase ++ path
+      Url.toString { devBase | path = path }
 
     else
-        path
+      UrlBuilder.absolute [path] []
 
 
 makeLocalServerUnisonCodebaseAPI : Bool -> UnisonCodebaseAPI


### PR DESCRIPTION
This adds some spa basic routing functionality, but lacks implementation for term and type routes and is still missing the ability to link directly to branches or code.