### PR TITLE
Spa

### DIFF
--- a/client-src/Ucb/Main/View/Branch.elm
+++ b/client-src/Ucb/Main/View/Branch.elm
@@ -369,7 +369,7 @@ viewCausal view hash causal =
                 , pointer
                 ]
                 -- TODO show full hash on hover
-                (text (String.left 7 hash_))
+                (link [] { url = "/branch/" ++ hash_, label = text (String.left 7 hash_) })
 
         viewParents : Element Message
         viewParents =

--- a/client-src/Ucb/Unison/Codebase/API/LocalServer.elm
+++ b/client-src/Ucb/Unison/Codebase/API/LocalServer.elm
@@ -15,22 +15,31 @@ import Unison.Reference exposing (..)
 import Unison.Symbol exposing (Symbol)
 import Unison.Term exposing (Term)
 import Unison.Type exposing (..)
+import Url exposing (..)
+import Url.Builder as UrlBuilder exposing (..)
 
 
 {-| Haskell server localhost base url
 -}
-devBase : String
+devBase : Url
 devBase =
-    "http://localhost:8180/"
+    { protocol = Http
+    , host = "localhost"
+    , port_ = Just 8180
+    , path = ""
+    , query = Nothing
+    , fragment = Nothing
+    }
+--  "http://localhost:8180/"
 
 
 prefixIfDev : Bool -> String -> String
 prefixIfDev isDev path =
     if isDev then
-        devBase ++ path
+        Url.toString { devBase | path = "/" ++ path }
 
     else
-        path
+        UrlBuilder.absolute [ path ] []
 
 
 makeLocalServerUnisonCodebaseAPI : Bool -> UnisonCodebaseAPI
@@ -50,7 +59,7 @@ getHeadHash isDev =
         { decoder = Json.Decode.string
         , headers = []
         , timeout = Nothing
-        , url = prefixIfDev isDev "head"
+        , url = prefixIfDev isDev "api/head"
         }
 
 
@@ -63,7 +72,7 @@ getPatch isDev hash =
         { decoder = V1.patchDecoder
         , headers = []
         , timeout = Nothing
-        , url = prefixIfDev isDev ("patch/" ++ hash)
+        , url = prefixIfDev isDev ("api/patch/" ++ hash)
         }
         |> Task.map (\response -> ( hash, response ))
 
@@ -77,7 +86,7 @@ getRawCausal isDev hash =
         { decoder = V1.rawCausalDecoder
         , headers = []
         , timeout = Nothing
-        , url = prefixIfDev isDev ("branch/" ++ hash)
+        , url = prefixIfDev isDev ("api/branch/" ++ hash)
         }
         |> Task.map (\response -> ( hash, response ))
 
@@ -91,7 +100,7 @@ getTerm isDev id =
         { decoder = V1.termDecoder
         , headers = []
         , timeout = Nothing
-        , url = prefixIfDev isDev ("term/" ++ idToString id ++ "/term")
+        , url = prefixIfDev isDev ("api/term/" ++ idToString id ++ "/term")
         }
         |> Task.map (\response -> ( id, response ))
 
@@ -105,7 +114,7 @@ getTermType isDev id =
         { decoder = V1.typeDecoder
         , headers = []
         , timeout = Nothing
-        , url = prefixIfDev isDev ("term/" ++ idToString id ++ "/type")
+        , url = prefixIfDev isDev ("api/term/" ++ idToString id ++ "/type")
         }
         |> Task.map (\response -> ( id, response ))
 
@@ -119,6 +128,6 @@ getTypeDecl isDev id =
         { decoder = V1.declarationDecoder
         , headers = []
         , timeout = Nothing
-        , url = prefixIfDev isDev ("declaration/" ++ idToString id)
+        , url = prefixIfDev isDev ("api/declaration/" ++ idToString id)
         }
         |> Task.map (\response -> ( id, response ))

--- a/server-src/Main.hs
+++ b/server-src/Main.hs
@@ -88,22 +88,15 @@ app cache request respond = do
     (requestMethod request <> " " <> rawPathInfo request)
 
   case request of
-    GET [] -> do
-      indexHtml <- getDataFileName "index.html"
-      respond
-        (responseFile
-          status200
-          [(hContentType, "text/html")]
-          indexHtml
-          Nothing)
 
-    GET ["branch", branch] ->
+    GET ["api", "branch", branch] ->
       handleGetBranch cache branch >>= respond
 
-    GET ["declaration", declaration] ->
+
+    GET ["api", "declaration", declaration] ->
       handleGetDeclaration cache declaration >>= respond
 
-    GET ["head"] -> do
+    GET ["api", "head"] -> do
       [head] <- listDirectory ".unison/v1/paths/_head"
       respond
         (responseLBS
@@ -111,7 +104,7 @@ app cache request respond = do
           [(hContentType, "application/json")]
           (LazyByteString.Char8.pack (show head)))
 
-    GET ["patch", patch] ->
+    GET ["api", "patch", patch] ->
       respond
         (responseFile
           status200
@@ -119,14 +112,20 @@ app cache request respond = do
           (".unison/v1/patches/" <> Text.unpack patch <> ".up")
           Nothing)
 
-    GET ["term", term, "term"] ->
+    GET ["api", "term", term, "term"] ->
       handleGetTerm cache term >>= respond
 
-    GET ["term", term, "type"] ->
+    GET ["api", "term", term, "type"] ->
       handleGetTermType cache term >>= respond
 
-    _ ->
-      respond (responseLBS status404 [] "")
+    _ -> do
+      indexHtml <- getDataFileName "index.html"
+      respond
+        (responseFile
+          status200
+          [(hContentType, "text/html")]
+          indexHtml
+          Nothing)
 
 handleGetBranch
   :: Cache


### PR DESCRIPTION
This adds basic spa functionality successfully, but:

-- missing working implementation for term/type/decl routes, and 

-- still has the issue of being unable to accept external links to branches/hashes, returning as a Bytes download rather than being processed through the View.