### PR TITLE
Make the search result list look a bit nicer

### DIFF
--- a/client-src/Ucb/Main/View.elm
+++ b/client-src/Ucb/Main/View.elm
@@ -350,7 +350,7 @@ viewSearch view =
             , placeholder = Just <| Element.Input.placeholder [] (text "Search")
             , label = Element.Input.labelHidden "Search"
             }
-        , column [ scrollbarY, centerX, height (fill |> maximum 500) ]
+        , column [ scrollbarY, centerX, height (fill |> maximum 500), width fill ]
             (List.map (nameToString >> text) matchingNames)
         ]
 


### PR DESCRIPTION
I was playing around with the search feature and realized there is some UI flickering.

## Before

![Screen Shot 2019-09-18 at 21 20 08](https://user-images.githubusercontent.com/29678/65182938-5507d800-da5a-11e9-9615-e43121d768b7.jpg)

## After

![Screen Shot 2019-09-18 at 21 19 55](https://user-images.githubusercontent.com/29678/65182953-5c2ee600-da5a-11e9-8c31-9a880b2ecf62.jpg)
