### PR TITLE
Jump to the top automatically

### DIFF
--- a/client-src/Main.elm
+++ b/client-src/Main.elm
@@ -1,6 +1,7 @@
 module Main exposing (..)
 
 import Browser
+import Browser.Dom as Dom
 import Browser.Navigation as Nav
 import Bytes exposing (Bytes)
 import HashingContainers.HashDict as HashDict exposing (HashDict)
@@ -139,6 +140,9 @@ update message model =
             ( model, Cmd.none )
 
         LinkClicked _ ->
+            ( model, Cmd.none )
+
+        NoOp ->
             ( model, Cmd.none )
 
 
@@ -442,6 +446,12 @@ update_Http_GetTermTypesAndTypeDecls2 ( termTypes, types ) model =
     )
 
 
+jumpToTop : Cmd Message
+jumpToTop =
+    Dom.setViewport 0.0 0.0
+        |> Task.perform (\_ -> NoOp)
+
+
 {-| Click a branch:
 
   - Fetch all of the new branch's types and terms.
@@ -477,7 +487,7 @@ update_User_ClickBranch path branch model =
                 |> Task.attempt Http_GetTermTypesAndTypeDecls
     in
     ( newModel
-    , command
+    , Cmd.batch [ command, jumpToTop ]
     )
 
 

--- a/client-src/Main.elm
+++ b/client-src/Main.elm
@@ -446,6 +446,8 @@ update_Http_GetTermTypesAndTypeDecls2 ( termTypes, types ) model =
     )
 
 
+{-| Scrolls back to the top of the browser page
+-}
 jumpToTop : Cmd Message
 jumpToTop =
     Dom.setViewport 0.0 0.0

--- a/client-src/Ucb/Main/Message.elm
+++ b/client-src/Ucb/Main/Message.elm
@@ -43,3 +43,4 @@ type Message
     | Http_GetTermTypesAndTypeDecls (Result (Http.Error Bytes) ( List ( Id, Type Symbol ), List ( Id, Declaration Symbol ) ))
     | UrlChanged Url.Url
     | LinkClicked Browser.UrlRequest
+    | NoOp


### PR DESCRIPTION
The sidebar gets quite long quite quickly. Clicking on any branch lets you stay on the current position, which can be a bit annoying as you wanted to see the content of this particular branch.

This PR forces elm to scroll back to the top