### PR TITLE
Fix bug where reference names would appear for every instance when only one was hovered over

### DIFF
--- a/client-src/Ucb/Main/Model.elm
+++ b/client-src/Ucb/Main/Model.elm
@@ -105,7 +105,7 @@ type alias ModelUI =
 {-| Hovering over what?
 -}
 type Hover
-    = HoverTerm Reference
+    = HoverTerm Int Reference
     | HoverType
         { type_ : Reference
         , path : List Int

--- a/client-src/Ucb/Main/View/Branch.elm
+++ b/client-src/Ucb/Main/View/Branch.elm
@@ -170,7 +170,7 @@ viewBranchTerm2 view i reference name _ =
                     name
     in
     case reference of
-        Builtin builtinContents ->
+        Builtin _ ->
             el
                 [ above <|
                     if view.hovered == Just (HoverTerm i reference) then

--- a/client-src/Ucb/Main/View/Branch.elm
+++ b/client-src/Ucb/Main/View/Branch.elm
@@ -170,10 +170,10 @@ viewBranchTerm2 view i reference name _ =
                     name
     in
     case reference of
-        Builtin _ ->
+        Builtin builtinContents ->
             el
                 [ above <|
-                    if view.hovered == Just (HoverTerm reference) then
+                    if view.hovered == Just (HoverTerm i reference) then
                         el
                             hoverStyle
                             (column
@@ -187,7 +187,7 @@ viewBranchTerm2 view i reference name _ =
                     else
                         none
                 , codeFont
-                , onMouseEnter (User_Hover (HoverTerm reference))
+                , onMouseEnter (User_Hover (HoverTerm i reference))
                 , onMouseLeave User_Unhover
                 ]
                 (text name2)
@@ -199,7 +199,7 @@ viewBranchTerm2 view i reference name _ =
                     ]
                     [ el
                         [ above <|
-                            if view.hovered == Just (HoverTerm reference) then
+                            if view.hovered == Just (HoverTerm i reference) then
                                 el
                                     hoverStyle
                                     (column
@@ -216,7 +216,7 @@ viewBranchTerm2 view i reference name _ =
                             else
                                 none
                         , onClick (User_ToggleTerm id)
-                        , onMouseEnter (User_Hover (HoverTerm reference))
+                        , onMouseEnter (User_Hover (HoverTerm i reference))
                         , onMouseLeave User_Unhover
                         , pointer
                         ]


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/5252770/68539321-ad1ed480-034f-11ea-886e-9a58d5577c44.png)



After:
![image](https://user-images.githubusercontent.com/5252770/68539319-9d9f8b80-034f-11ea-8245-5247ce4cc091.png)
