### PR TITLE
Show current namespace above list of types and terms

### DIFF
--- a/client-src/Ucb/Main/View.elm
+++ b/client-src/Ucb/Main/View.elm
@@ -169,8 +169,8 @@ viewView view =
         , row [ padding 20, width fill ]
             [ el [ alignTop, width <| fillPortion 2, scrollbars ]
                 (case view.branch of
-                    ( _, ( hash, branch ) ) ->
-                        viewBranch view hash branch
+                    ( branchName, ( hash, branch ) ) ->
+                        viewBranch view branchName hash branch
                 )
             , column
                 [ alignTop


### PR DESCRIPTION
Before:

![2019-11-16 18 36 27](https://user-images.githubusercontent.com/5252770/69000616-66296580-08a0-11ea-995d-6aa7144186ba.gif)


After:

![2019-11-16 18 37 08](https://user-images.githubusercontent.com/5252770/69000620-6aee1980-08a0-11ea-8165-008be3145ad9.gif)
