### PR TITLE
Bump elm-browser dependency for new debugger

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "direct": {
       "NoRedInk/elm-json-decode-pipeline": "1.0.0",
-      "elm/browser": "1.0.1",
+      "elm/browser": "1.0.2",
       "elm/bytes": "1.0.8",
       "elm/core": "1.0.2",
       "elm/html": "1.0.0",


### PR DESCRIPTION
Sadly still seeing the debugger keel over when the codebase is big enough